### PR TITLE
feat(wasm): add modelInfo to ConvertResult

### DIFF
--- a/src/wasm/bindings.cpp
+++ b/src/wasm/bindings.cpp
@@ -261,12 +261,16 @@ public:
       if (!ir_or)
         return err(ir_or.error().message);
 
+      // Get modelInfo using input data size
+      gf::ModelInfo info = gf::GetModelInfo(ir_or.value(), data.size());
+
       auto out_or = writer->Write(ir_or.value(), {strict});
       if (!out_or)
         return err(out_or.error().message);
 
       val res = val::object();
       res.set("data", vectorToUint8Array(out_or.value()));
+      res.set("modelInfo", modelInfoToJS(info));
       return res;
     } catch (const std::exception &e) {
       return err(e.what());

--- a/wasm/base.ts
+++ b/wasm/base.ts
@@ -95,7 +95,8 @@ export abstract class GaussForgeBase {
         const result = this.instance!.convert(input, inFmt, outFmt, options.strict || false);
         if (result.error) throw new Error(result.error);
         return {
-            data: result.data
+            data: result.data,
+            ...(result.modelInfo && { modelInfo: result.modelInfo })
         } as ConvertResult;
     }
 

--- a/wasm/example/test.js
+++ b/wasm/example/test.js
@@ -114,7 +114,7 @@ async function test() {
         }
 
         // 5. Test format conversion
-        console.log('4️⃣  Testing format conversion...');
+        console.log('5️⃣  Testing format conversion...');
         const outputFormats = ['splat', 'ksplat', 'spz', 'ply', 'compressed.ply', 'sog'];
 
         for (const outFormat of outputFormats) {
@@ -126,6 +126,14 @@ async function test() {
             try {
                 const convertResult = await gaussForge.convert(inputData, 'ply', outFormat);
                 console.log(`   ✅ ply -> ${outFormat}: ${convertResult.data.length} bytes`);
+
+                // Verify modelInfo exists
+                if (convertResult.modelInfo) {
+                    const info = convertResult.modelInfo;
+                    console.log(`      📊 Points: ${info.basic.numPoints}`);
+                    console.log(`      🎨 SH degree: ${info.rendering.shDegree}`);
+                    console.log(`      💾 Total size: ${info.sizes.total}`);
+                }
 
                 // Optionally: Save conversion result
                 const outputFile = path.join(__dirname, `output.${outFormat}`);

--- a/wasm/types.ts
+++ b/wasm/types.ts
@@ -32,6 +32,7 @@ export interface WriteResult {
 
 export interface ConvertResult {
     data: Uint8Array;
+    modelInfo?: ModelInfo;
     warning?: string;
     error?: string;
 }


### PR DESCRIPTION
Include model metadata in convert() return value to avoid requiring a separate getModelInfo() call when converting file formats.